### PR TITLE
Initial implementation of beepboop resourcer

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2011-2016 Robots And Pencils
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,25 @@
 
 beepboop-js allows bot developers to run on the [Beep Boop HQ](http://beepboophq.com) bot hosting platform and support multiple teams from a single bot process. Simply require 'beepboop' in your bot project and listen for events indicating a user has requested your bot to be added, updated, or removed from their team.
 
-If you are using [Botkit](http://github.com/howdyai/botkit), we recommend using [beepboop-botkit](http://github.com/BeepBoopHQ/beepboop-botkit) as spawning and connecting to teams is handled for you.
+If you are using [Botkit](http://github.com/howdyai/botkit), we recommend using [beepboop-botkit](http://github.com/BeepBoopHQ/beepboop-botkit) so spawning and connecting to teams is handled for you.
 
 ## Install
 `npm install --save beepboop`
 
 ## Use
+### Testing your bot locally
+*TODO: add steps to test with dev-resourcer*
+
+At a minimum, the client needs the following environment variables set which can be obtained from the development area of the http://beebboophq.com site.
+
+  * `BEEPBOOP_RESOURCER` -- url to the Beep Boop Server
+  * `BEEPBOOP_TOKEN`
+  * `BEEPBOOP_ID`
+
+In production, these values will be set automatically.
+
+Connect to Beep Boop and listen for events like so:
+
   var BeepBoop = require('beepboop')
 
   var beepboop = BeepBoop.start()
@@ -24,7 +37,7 @@ If you are using [Botkit](http://github.com/howdyai/botkit), we recommend using 
     // handle adding team to bot
   })
 
-see `bot.js` for an example.
+see `examples/simple.js` for more.
 
 ## Module: beepboop
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # WIP - Not ready for use.
 
-## beepboop-js allows bot developers to efficiently run multiple teams from a single bot.
+## The beepboop bot management node module
 
-Events emitted from beepboop enables you to know when a team owner adds, updates, or removes your bot from their team.
+beepboop-js allows bot developers to run on the [Beep Boop HQ](http://beepboophq.com) bot hosing platform and support multiple teams from a single bot process. Simply require 'beepboop' in your bot project and listen for events indicating a user has requested your bot to be added, updated, or removed from their team.
 
-If you are using botkit, we recommend using beepboop-botkit (it wraps this module) vs. the beepboop module directly.
+If you are using [Botkit](http://github.com/howdyai/botkit), we recommend using [beepboop-botkit](http://github.com/BeepBoopHQ/beepboop-botkit) as spawning and connecting to teams is handled for you.
 
 ## Install
 `npm install --save beepboop`
@@ -14,6 +14,7 @@ If you are using botkit, we recommend using beepboop-botkit (it wraps this modul
 
   var beepboop = BeepBoop.start()
 
+  // listen for events
   beepboop.on('open', function () {
     console.log('connected to resource server')
   })
@@ -23,6 +24,7 @@ If you are using botkit, we recommend using beepboop-botkit (it wraps this modul
     // handle adding team to bot
   })
 
+see `bot.js` for an example.
 
 ## Module: beepboop
 
@@ -64,8 +66,6 @@ Is emitted when an add_resource message is received indicating a user has reques
 `function (message) { }`
 
 Is emitted when an update_resource message is received indicating a request to update the instance of the bot has been sent. The bot maker updating the bot, or a bot owner updating configuration are two cases that can trigger an update.
-
-`update_resource performs remove_resource & add_resource and those events are also emitted -- TODO: should they be suppresed in this case?`
 
 
 ### Event: 'message.remove_resource'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## The beepboop bot management node module
 
-beepboop-js allows bot developers to run on the [Beep Boop HQ](http://beepboophq.com) bot hosing platform and support multiple teams from a single bot process. Simply require 'beepboop' in your bot project and listen for events indicating a user has requested your bot to be added, updated, or removed from their team.
+beepboop-js allows bot developers to run on the [Beep Boop HQ](http://beepboophq.com) bot hosting platform and support multiple teams from a single bot process. Simply require 'beepboop' in your bot project and listen for events indicating a user has requested your bot to be added, updated, or removed from their team.
 
 If you are using [Botkit](http://github.com/howdyai/botkit), we recommend using [beepboop-botkit](http://github.com/BeepBoopHQ/beepboop-botkit) as spawning and connecting to teams is handled for you.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-WIP - Not ready for use.
+# WIP - Not ready for use.
+
+## beepboop-js allows bot developers to efficiently run multiple teams from a single bot.
+
+Events emitted from beepboop enables you to know when a team owner adds, updates, or removes your bot from their team.
+
+If you are using botkit, we recommend using beepboop-botkit (it wraps this module) vs. the beepboop module directly.
+
+## Install
+`npm install --save beepboop`
+
+## Use
+  var BeepBoop = require('beepboop')
+
+  var beepboop = BeepBoop.start()
+
+  beepboop.on('open', function () {
+    console.log('connected to resource server')
+  })
+
+  beepboop.on('message.add_resource', function (msg) {
+    console.log('received request to add bot to team')
+    // handle adding team to bot
+  })
+
+
+## Module: beepboop
+
+Module has exported function `start`
+
+### beepboop.start([options])
+
+* `options` Object
+  * `debug` Boolean
+
+### Event: 'open'
+
+`function () { }`
+
+Emitted when the connection is established.
+
+### Event: 'error'
+
+`function (error) { }`
+
+If the client emits an error, this event is emitted (errors from the underlying `net.Socket` are forwarded here).
+
+### Event: 'close'
+
+`function (code, message) { }`
+
+Is emitted when the connection is closed. `code` is defined in the WebSocket specification.
+
+The `close` event is also emitted when then underlying `net.Socket` closes the connection (`end` or `close`).
+
+### Event: 'message.add_resource'
+
+`function (message) { }`
+
+Is emitted when an add_resource message is received indicating a user has requested an instance of the bot to be added to their team.
+
+### Event: 'message.update_resource'
+
+`function (message) { }`
+
+Is emitted when an update_resource message is received indicating a request to update the instance of the bot has been sent. The bot maker updating the bot, or a bot owner updating configuration are two cases that can trigger an update.
+
+`update_resource performs remove_resource & add_resource and those events are also emitted -- TODO: should they be suppresed in this case?`
+
+
+### Event: 'message.remove_resource'
+
+`function (message) { }`
+
+Is emitted when an remove_resource message is received indicating a bot owner has removed a bot from their team.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using [Botkit](http://github.com/howdyai/botkit), we recommend using 
     console.log('connected to resource server')
   })
 
-  beepboop.on('message.add_resource', function (msg) {
+  beepboop.on('add_resource', function (msg) {
     console.log('received request to add bot to team')
     // handle adding team to bot
   })
@@ -55,20 +55,20 @@ Is emitted when the connection is closed. `code` is defined in the WebSocket spe
 
 The `close` event is also emitted when then underlying `net.Socket` closes the connection (`end` or `close`).
 
-### Event: 'message.add_resource'
+### Event: 'add_resource'
 
 `function (message) { }`
 
 Is emitted when an add_resource message is received indicating a user has requested an instance of the bot to be added to their team.
 
-### Event: 'message.update_resource'
+### Event: 'update_resource'
 
 `function (message) { }`
 
 Is emitted when an update_resource message is received indicating a request to update the instance of the bot has been sent. The bot maker updating the bot, or a bot owner updating configuration are two cases that can trigger an update.
 
 
-### Event: 'message.remove_resource'
+### Event: 'remove_resource'
 
 `function (message) { }`
 

--- a/bot.js
+++ b/bot.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var BeepBoop = require(__dirname + '/lib/beepboop.js')
+var BeepBoop = require('beepboop')
 
 var config = {debug: true}
 var beepboop = BeepBoop.start(config)
@@ -9,27 +9,23 @@ beepboop.on('open', function () {
   console.log('connected to resource server')
 })
 
-beepboop.on('message.add_resource', function (msg) {
+beepboop.on('add_resource', function (msg) {
   console.log('bot added to a team: ' + JSON.stringify(msg))
   // handle adding team to bot
 })
 
-beepboop.on('message.update_resource', function (msg) {
+beepboop.on('update_resource', function (msg) {
   console.log('a team\'s bot was updated: ' + JSON.stringify(msg))
   // handle updating existing team's to bot (could be update to bot version or a config change)
 })
 
-beepboop.on('message.remove_resource', function (msg) {
+beepboop.on('remove_resource', function (msg) {
   console.log('bot removed form team: ' + JSON.stringify(msg))
   // handle removing team from bot
 })
 
 beepboop.on('error', function (err) {
   console.log(err)
-})
-
-beepboop.on('message.*', function (data) {
-  console.log('listen to all the things! ' + JSON.stringify(data))
 })
 
 // implement slack bot

--- a/bot.js
+++ b/bot.js
@@ -1,0 +1,31 @@
+'use strict'
+
+var BeepBoop = require(__dirname + '/lib/beepboop.js')
+
+var config = {debug: true}
+var beepboop = BeepBoop.init(config)
+
+beepboop.on('message.add_resource', function (msg) {
+  console.log('bot added to a team: ' + JSON.stringify(msg))
+  // handle adding team to bot
+})
+
+beepboop.on('message.update_resource', function (msg) {
+  console.log('a team\'s bot was updated: ' + JSON.stringify(msg))
+  // handle updating existing team's to bot (could be update to bot version or a config change)
+})
+
+beepboop.on('message.remove_resource', function (msg) {
+  console.log('bot removed form team: ' + JSON.stringify(msg))
+  // handle removing team from bot
+})
+
+beepboop.on('error', function (err) {
+  console.log(err)
+})
+
+beepboop.on('message.*', function (data) {
+  console.log('listen to all the things! ' + JSON.stringify(data))
+})
+
+// implement slack bot

--- a/bot.js
+++ b/bot.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var BeepBoop = require('beepboop')
+var BeepBoop = require('./lib/beepboop')
 
 var config = {debug: true}
 var beepboop = BeepBoop.start(config)

--- a/bot.js
+++ b/bot.js
@@ -3,7 +3,11 @@
 var BeepBoop = require(__dirname + '/lib/beepboop.js')
 
 var config = {debug: true}
-var beepboop = BeepBoop.init(config)
+var beepboop = BeepBoop.start(config)
+
+beepboop.on('open', function () {
+  console.log('connected to resource server')
+})
 
 beepboop.on('message.add_resource', function (msg) {
   console.log('bot added to a team: ' + JSON.stringify(msg))

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,12 +1,22 @@
 'use strict'
 
-var BeepBoop = require('./lib/beepboop')
+var BeepBoop = require('../lib/beepboop')
+// var winston = require('winston')
+// var logger = new (winston.Logger)({
+//   transports: [new (winston.transports.Console)({ level: 'debug' })]
+// })
 
-var config = {debug: true}
+// optional config including ability to pass a logger
+var config = {
+  debug: true
+  // logger: logger
+}
+
 var beepboop = BeepBoop.start(config)
 
 beepboop.on('open', function () {
   console.log('connected to resource server')
+  // logger.info('connected to resource server')
 })
 
 beepboop.on('add_resource', function (msg) {
@@ -15,7 +25,7 @@ beepboop.on('add_resource', function (msg) {
 })
 
 beepboop.on('update_resource', function (msg) {
-  console.log('a team\'s bot was updated: ' + JSON.stringify(msg))
+  console.info('a team\'s bot was updated: ' + JSON.stringify(msg))
   // handle updating existing team's to bot (could be update to bot version or a config change)
 })
 

--- a/lib/beepboop.js
+++ b/lib/beepboop.js
@@ -3,8 +3,8 @@
 var Resourcer = require(__dirname + '/resourcer.js')
 
 module.exports = {
-  start: function (config) {
-    var resourcer = Resourcer(config)
+  start: function (options) {
+    var resourcer = Resourcer(options)
     resourcer.connect()
     return resourcer
   }

--- a/lib/beepboop.js
+++ b/lib/beepboop.js
@@ -1,7 +1,11 @@
 'use strict'
 
-var resourcer = require(__dirname + '/resourcer.js')
+var Resourcer = require(__dirname + '/resourcer.js')
 
 module.exports = {
-  init: resourcer.init
+  start: function (config) {
+    var resourcer = Resourcer(config)
+    resourcer.connect()
+    return resourcer
+  }
 }

--- a/lib/beepboop.js
+++ b/lib/beepboop.js
@@ -1,0 +1,7 @@
+'use strict'
+
+var resourcer = require(__dirname + '/resourcer.js')
+
+module.exports = {
+  init: resourcer.init
+}

--- a/lib/beepboop.js
+++ b/lib/beepboop.js
@@ -1,11 +1,9 @@
 'use strict'
 
-var Resourcer = require(__dirname + '/resourcer.js')
+var Resourcer = require('./resourcer.js')
 
 module.exports = {
   start: function (options) {
-    var resourcer = Resourcer(options)
-    resourcer.connect()
-    return resourcer
+    return Resourcer(options).connect()
   }
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,6 @@
 
 // Keeping it simple. The default logger only logs (at any level)
-// if debug is true. In error cases, where you might assume we should alwasy log
+// if debug is true. In error cases, where you might assume we should always log
 // the errors are emitted so the consuming code has an opportunity to handle.
 module.exports = function Logger (debug) {
   return {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,21 @@
+
+// Keeping it simple. The default logger only logs (at any level)
+// if debug is true. In error cases, where you might assume we should alwasy log
+// the errors are emitted so the consuming code has an opportunity to handle.
+module.exports = function Logger (debug) {
+  return {
+    debug: function () {
+      if (debug) {
+        var args = ['debug: '].concat(Array.prototype.slice.call(arguments))
+        console.log.apply(console, args)
+      }
+    },
+
+    error: function () {
+      if (debug) {
+        var args = ['error: '].concat(Array.prototype.slice.call(arguments))
+        console.log.apply(console, args)
+      }
+    }
+  }
+}

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -3,7 +3,7 @@
 var WebSocket = require('ws')
 var EventEmitter2 = require('eventemitter2').EventEmitter2
 var deap = require('deap')
-var retry = require('./retry.js')
+var Retry = require('./retry')
 
 module.exports = function Resourcer (config) {
   config = parseConfig(config)
@@ -11,6 +11,7 @@ module.exports = function Resourcer (config) {
 
   var ws = null
   var resourcer = new EventEmitter2({wildcard: true})
+  var retry = Retry()
 
   resourcer.connect = function (inWs) {
     ws = initWs(inWs)
@@ -19,6 +20,8 @@ module.exports = function Resourcer (config) {
       .on('message', handledMessage)
       .on('close', handledClose)
       .on('error', handledError)
+
+    return resourcer
   }
 
   function parseConfig (config) {
@@ -36,11 +39,9 @@ module.exports = function Resourcer (config) {
   // cleanup and recreate ws connection for retry and mock case
   function initWs (inWs) {
     if (ws) {
-      ws
-        .removeAllListeners(handledOpen)
-        .removeAllListeners(handledError)
-        .removeAllListeners(handledClose)
-        .removeAllListeners(handledMessage)
+      ws.removeAllListeners()
+      // this is a noop if already closed
+      ws.close()
     }
 
     return inWs || newWs()
@@ -51,6 +52,7 @@ module.exports = function Resourcer (config) {
       var ws = new WebSocket(config.serverURL)
     } catch (e) {
       log.error('Invalid BEEPBOOP_RESOURCER environment variable value:', config.serverURL, e.toString())
+      // Exit process, this only occurs if the serverURL isn't a valid url
       process.exit(1)
     }
 
@@ -66,13 +68,15 @@ module.exports = function Resourcer (config) {
 
     ws.send(JSON.stringify(authMsg), function ack (err) {
       if (err) {
-        ws.emit('error', err)
+        handledError(err)
         log.error('Authorization to the Beep Boop Server failed with:', err.toString())
       }
     })
 
     resourcer.emit('open')
     log.debug('Web Socket connection opened to Beep Boop Server:', config.serverURL)
+    // Reset retry backoff
+    retry = Retry()
   }
 
   function handledError (err) {
@@ -85,13 +89,14 @@ module.exports = function Resourcer (config) {
       'Attempting to reconnect...'
     )
 
-    retry.attempt(resourcer.connect)
+    retry(resourcer.connect)
   }
 
   function handledClose (code, message) {
     resourcer.emit('close', code, message)
     log.debug('Connection to Beep Boop server closed.', code, message)
-    retry.attempt(resourcer.connect)
+
+    retry(resourcer.connect)
   }
 
   function handledMessage (payload) {

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -1,0 +1,123 @@
+'use strict'
+
+var WebSocket = require('ws')
+var EventEmitter2 = require('eventemitter2').EventEmitter2
+// var events = require('events')
+
+const connInfo = {
+  token: process.env.BEEPBOOP_TOKEN || 'development_token',
+  id: process.env.BEEPBOOP_ID || 'development_pod',
+  url: process.env.BEEPBOOP_RESOURCER || 'ws://localhost:9000/ws',
+  port: 443,
+  path: '/ws',
+  method: 'GET'
+}
+
+const authMsg = {
+  type: 'auth',
+  id: connInfo.id,
+  token: connInfo.token
+}
+
+exports.init = function () {
+  var resourcer = new Resourcer()
+  resourcer.connect()
+  return resourcer
+}
+
+function Resourcer (ws) {
+  this.newWs = function () {
+    return new WebSocket(connInfo.url)
+  }
+  if (!ws) {
+    ws = this.newWs()
+  }
+  this.ws = ws
+  this.retryInterval = 1000
+
+  process.on('uncaughtException', (err) => {
+    console.log('uncaughtException: ' + err)
+  })
+
+  this.connect = function () {
+    var self = this
+
+    this.ws = this.newWs()
+
+    this.ws.on('open', function (data) {
+      self.retryInterval = 1000
+      self.ws.send(JSON.stringify(authMsg), function ack (err) {
+        if (err) {
+          self.emit('error', err)
+        }
+      })
+
+      self.emit('open', data)
+    })
+
+    this.ws.on('error', function (err) {
+      self.emit('error', err)
+      self.retry()
+    })
+
+    this.ws.on('close', function (reason) {
+      self.emit('close', reason)
+      self.retry()
+    })
+
+    this.ws.on('message', function (payload) {
+      var msg = null
+      try {
+        msg = JSON.parse(payload)
+        self.emitMsgTypes(msg)
+      } catch (err) {
+        self.emit('error', err)
+        return
+      }
+    })
+  }
+
+  this.emitMsgTypes = function (msg) {
+    switch (msg.type) {
+      case 'add_resource':
+        // TODO: should this be 'bot.add_team'?
+        // then later we could slash.add_team & web.add_team?
+        this.emit('message.add_resource', msg)
+        break
+      case 'update_resource':
+        this.emit('message.udpdate_resource', msg)
+        break
+      case 'remove_resource':
+        this.emit('message.remove_resource', msg)
+        break
+      case 'auth_result':
+        this.emit('message.auth_result', msg)
+        break
+      default:
+        this.emit('message', msg)
+    }
+  }
+
+  // TODO prolly should pull in something more robuts.
+  // need max attempts
+  this.retry = function () {
+    var self = this
+    var time = self.getRetryInterval(self.retryInterval)
+
+    setTimeout(function () {
+      self.retryInterval = time
+      self.connect()
+      return time
+    }, time)
+  }
+
+  this.getRetryInterval = function (currentInterval) {
+    var max = 30000
+    var newInterval = Math.ceil(currentInterval * (1.2 + Math.random()))
+    if (newInterval > max) newInterval = max
+    console.log(newInterval)
+    return newInterval
+  }
+}
+
+Resourcer.prototype = new EventEmitter2({wildcard: true})

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -32,10 +32,9 @@ module.exports = function Resourcer (options) {
     }, options || {})
   }
 
-  // handle enables retry ws cleanup and mocking
+  // cleanup and recreate ws connection for retry and mock case
   function initWs (inWs) {
     if (ws) {
-      // prevent leaks in retry case
       ws
         .removeAllListeners(handledOpen)
         .removeAllListeners(handledError)

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -2,122 +2,84 @@
 
 var WebSocket = require('ws')
 var EventEmitter2 = require('eventemitter2').EventEmitter2
+var retry = require(__dirname + '/retry.js')
 
-const connInfo = {
+const CONN_INFO = {
   token: process.env.BEEPBOOP_TOKEN || 'development_token',
   id: process.env.BEEPBOOP_ID || 'development_pod',
-  url: process.env.BEEPBOOP_RESOURCER || 'ws://localhost:9000/ws',
-  port: 443,
-  path: '/ws',
-  method: 'GET'
+  url: process.env.BEEPBOOP_RESOURCER || 'ws://localhost:9000/ws'
 }
 
-const authMsg = {
+const AUTH_MSG = {
   type: 'auth',
-  id: connInfo.id,
-  token: connInfo.token
+  id: CONN_INFO.id,
+  token: CONN_INFO.token
 }
 
-exports.init = function () {
-  var resourcer = new Resourcer()
-  resourcer.connect()
-  return resourcer
-}
+const MSG_PREFIX = 'message'
 
-function Resourcer () {
-  this.retryInterval = 1000
+module.exports = function Resourcer (options) {
+  var ws = null
+  var resourcer = new EventEmitter2({wildcard: true})
 
-  process.on('uncaughtException', (err) => {
-    console.log('uncaughtException: ' + err)
-    throw new Error(err)
-  })
-
-  this.newWs = function () {
-    return new WebSocket(connInfo.url)
+  resourcer.connect = function (inWs) {
+    ws = initWs(inWs)
+    ws
+      .on('open', handledOpen)
+      .on('message', handledMessage)
+      .on('close', handledClose)
+      .on('error', handledError)
   }
 
-  this.connect = function (ws) {
-    var self = this
-    if (!ws) {
-      ws = this.newWs()
+  // handle enables retry ws cleanup and mocking
+  function initWs (inWs) {
+    if (ws) {
+      // prevent leaks in retry case
+      ws
+        .removeAllListeners(handledOpen)
+        .removeAllListeners(handledError)
+        .removeAllListeners(handledClose)
+        .removeAllListeners(handledMessage)
     }
-    this.ws = ws
 
-    this.ws.on('open', function (data) {
-      self.retryInterval = 1000
-      self.ws.send(JSON.stringify(authMsg), function ack (err) {
-        if (err) {
-          self.emit('error', err)
-        }
-      })
+    return inWs || new WebSocket(CONN_INFO.url)
+  }
 
-      self.emit('open', data)
-    })
-
-    this.ws.on('error', function (err) {
-      self.emit('error', err)
-      self.retry()
-    })
-
-    this.ws.on('close', function (reason) {
-      self.emit('close', reason)
-      self.retry()
-    })
-
-    this.ws.on('message', function (payload) {
-      var msg = null
-      try {
-        msg = JSON.parse(payload)
-        self.emitMsgTypes(msg)
-      } catch (err) {
-        self.emit('error', err)
-        return
+  function handledOpen () {
+    ws.send(JSON.stringify(AUTH_MSG), function ack (err) {
+      if (err) {
+        ws.emit('error', err)
       }
     })
+
+    resourcer.emit('open')
   }
 
-  this.emitMsgTypes = function (msg) {
-    switch (msg.type) {
-      case 'add_resource':
-        // TODO: should this be 'bot.add_team'?
-        // then later we could slash.add_team & web.add_team?
-        this.emit('message.add_resource', msg)
-        break
-      case 'update_resource':
-        this.emit('message.update_resource', msg)
-        break
-      case 'remove_resource':
-        this.emit('message.remove_resource', msg)
-        break
-      case 'auth_result':
-        this.emit('message.auth_result', msg)
-        break
-      default:
-        this.emit('message', msg)
+  function handledError (err) {
+    resourcer.emit('error', err)
+    retry.attempt(resourcer.connect)
+  }
+
+  function handledClose (reason) {
+    resourcer.emit('close', reason)
+    retry.attempt(resourcer.connect)
+  }
+
+  function handledMessage (payload) {
+    var msg = null
+    try {
+      msg = JSON.parse(payload)
+      var evt = namespace(msg)
+      resourcer.emit(evt, msg)
+    } catch (err) {
+      resourcer.emit('error', err)
+      return
     }
   }
 
-  // TODO pull in something more robuts. need max attempts constraint
-  this.retry = function () {
-    var self = this
-    var time = self.getRetryInterval(self.retryInterval)
-
-    setTimeout(function () {
-      self.retryInterval = time
-      self.connect()
-      return time
-    }, time)
+  function namespace (msg) {
+    return msg.type ? MSG_PREFIX + '.' + msg.type : ''
   }
 
-  this.getRetryInterval = function (currentInterval) {
-    var max = 30000
-    var newInterval = Math.ceil(currentInterval * (1.2 + Math.random()))
-    if (newInterval > max) newInterval = max
-    console.log(newInterval)
-    return newInterval
-  }
+  return resourcer
 }
-
-Resourcer.prototype = new EventEmitter2({wildcard: true})
-
-exports.Resourcer = Resourcer

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -2,19 +2,8 @@
 
 var WebSocket = require('ws')
 var EventEmitter2 = require('eventemitter2').EventEmitter2
-var retry = require(__dirname + '/retry.js')
-
-const CONN_INFO = {
-  token: process.env.BEEPBOOP_TOKEN || 'development_token',
-  id: process.env.BEEPBOOP_ID || 'development_pod',
-  url: process.env.BEEPBOOP_RESOURCER || 'ws://localhost:9000/ws'
-}
-
-const AUTH_MSG = {
-  type: 'auth',
-  id: CONN_INFO.id,
-  token: CONN_INFO.token
-}
+var deap = require('deap')
+var retry = require('./retry.js')
 
 const MSG_PREFIX = 'message'
 
@@ -35,12 +24,12 @@ module.exports = function Resourcer (options) {
   }
 
   function parseOptions (options) {
-    var opts = {}
-
-    // set supported options
-    opts.debug = !!opts.debug
-
-    return opts
+    return deap.update({
+      debug: false,
+      token: process.env.BEEPBOOP_TOKEN || 'development_token',
+      id: process.env.BEEPBOOP_ID || 'development_pod',
+      url: process.env.BEEPBOOP_RESOURCER || 'ws://localhost:9000/ws'
+    }, options || {})
   }
 
   // handle enables retry ws cleanup and mocking
@@ -54,11 +43,17 @@ module.exports = function Resourcer (options) {
         .removeAllListeners(handledMessage)
     }
 
-    return inWs || new WebSocket(CONN_INFO.url)
+    return inWs || new WebSocket(options.url)
   }
 
   function handledOpen () {
-    ws.send(JSON.stringify(AUTH_MSG), function ack (err) {
+    var authMsg = {
+      type: 'auth',
+      id: options.id,
+      token: options.token
+    }
+
+    ws.send(JSON.stringify(authMsg), function ack (err) {
       if (err) {
         ws.emit('error', err)
       }

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -5,9 +5,9 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
 var deap = require('deap')
 var retry = require('./retry.js')
 
-module.exports = function Resourcer (options) {
-  // TODO add log level based on debug flag
-  options = parseOptions(options)
+module.exports = function Resourcer (config) {
+  config = parseConfig(config)
+  var log = config.logger || require('./logger.js')(config.debug)
 
   var ws = null
   var resourcer = new EventEmitter2({wildcard: true})
@@ -21,13 +21,16 @@ module.exports = function Resourcer (options) {
       .on('error', handledError)
   }
 
-  function parseOptions (options) {
-    return deap.update({
+  function parseConfig (config) {
+    var cfg = deap.update({
       debug: false,
-      token: process.env.BEEPBOOP_TOKEN || 'development_token',
-      id: process.env.BEEPBOOP_ID || 'development_pod',
-      url: process.env.BEEPBOOP_RESOURCER || 'ws://localhost:9000/ws'
-    }, options || {})
+      token: process.env.BEEPBOOP_TOKEN,
+      id: process.env.BEEPBOOP_ID,
+      serverURL: process.env.BEEPBOOP_RESOURCER,
+      logger: null
+    }, config || {})
+
+    return cfg
   }
 
   // cleanup and recreate ws connection for retry and mock case
@@ -40,34 +43,54 @@ module.exports = function Resourcer (options) {
         .removeAllListeners(handledMessage)
     }
 
-    return inWs || new WebSocket(options.url)
+    return inWs || newWs()
+  }
+
+  function newWs () {
+    try {
+      var ws = new WebSocket(config.serverURL)
+    } catch (e) {
+      log.error('Invalid BEEPBOOP_RESOURCER environment variable value:', config.serverURL, e.toString())
+      process.exit(1)
+    }
+
+    return ws
   }
 
   function handledOpen () {
     var authMsg = {
       type: 'auth',
-      id: options.id,
-      token: options.token
+      id: config.id,
+      token: config.token
     }
 
     ws.send(JSON.stringify(authMsg), function ack (err) {
       if (err) {
         ws.emit('error', err)
+        log.error('Authorization to the Beep Boop Server failed with:', err.toString())
       }
     })
 
     resourcer.emit('open')
+    log.debug('Web Socket connection opened to Beep Boop Server:', config.serverURL)
   }
 
   function handledError (err) {
     resourcer.emit('error', err)
-    if (err.code !== 'ECONNREFUSED' && err.address !== '127.0.0.1') {
-      retry.attempt(resourcer.connect)
-    }
+    log.error(
+      'Beep Boop server connection error.',
+      config.serverURL,
+      err.toString(),
+      '. Verify the BEEPBOOP_RESOURCER environment variable is set correctly.',
+      'Attempting to reconnect...'
+    )
+
+    retry.attempt(resourcer.connect)
   }
 
   function handledClose (code, message) {
     resourcer.emit('close', code, message)
+    log.debug('Connection to Beep Boop server closed.', code, message)
     retry.attempt(resourcer.connect)
   }
 
@@ -76,8 +99,10 @@ module.exports = function Resourcer (options) {
     try {
       msg = JSON.parse(payload)
       resourcer.emit(msg.type, msg)
+      log.debug('Message received from Beep Boop server: ', JSON.stringify(msg))
     } catch (err) {
       resourcer.emit('error', err)
+      log.error('Error attempting JSON.parse of message from Beep Boop server. ', err.toString())
       return
     }
   }

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -5,8 +5,6 @@ var EventEmitter2 = require('eventemitter2').EventEmitter2
 var deap = require('deap')
 var retry = require('./retry.js')
 
-const MSG_PREFIX = 'message'
-
 module.exports = function Resourcer (options) {
   // TODO add log level based on debug flag
   options = parseOptions(options)
@@ -75,16 +73,11 @@ module.exports = function Resourcer (options) {
     var msg = null
     try {
       msg = JSON.parse(payload)
-      var evt = namespace(msg)
-      resourcer.emit(evt, msg)
+      resourcer.emit(msg.type, msg)
     } catch (err) {
       resourcer.emit('error', err)
       return
     }
-  }
-
-  function namespace (msg) {
-    return msg.type ? MSG_PREFIX + '.' + msg.type : ''
   }
 
   return resourcer

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -66,8 +66,8 @@ module.exports = function Resourcer (options) {
     retry.attempt(resourcer.connect)
   }
 
-  function handledClose (reason) {
-    resourcer.emit('close', reason)
+  function handledClose (code, message) {
+    resourcer.emit('close', code, message)
     retry.attempt(resourcer.connect)
   }
 

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -2,7 +2,6 @@
 
 var WebSocket = require('ws')
 var EventEmitter2 = require('eventemitter2').EventEmitter2
-// var events = require('events')
 
 const connInfo = {
   token: process.env.BEEPBOOP_TOKEN || 'development_token',
@@ -25,24 +24,24 @@ exports.init = function () {
   return resourcer
 }
 
-function Resourcer (ws) {
-  this.newWs = function () {
-    return new WebSocket(connInfo.url)
-  }
-  if (!ws) {
-    ws = this.newWs()
-  }
-  this.ws = ws
+function Resourcer () {
   this.retryInterval = 1000
 
   process.on('uncaughtException', (err) => {
     console.log('uncaughtException: ' + err)
+    throw new Error(err)
   })
 
-  this.connect = function () {
-    var self = this
+  this.newWs = function () {
+    return new WebSocket(connInfo.url)
+  }
 
-    this.ws = this.newWs()
+  this.connect = function (ws) {
+    var self = this
+    if (!ws) {
+      ws = this.newWs()
+    }
+    this.ws = ws
 
     this.ws.on('open', function (data) {
       self.retryInterval = 1000
@@ -85,7 +84,7 @@ function Resourcer (ws) {
         this.emit('message.add_resource', msg)
         break
       case 'update_resource':
-        this.emit('message.udpdate_resource', msg)
+        this.emit('message.update_resource', msg)
         break
       case 'remove_resource':
         this.emit('message.remove_resource', msg)
@@ -98,8 +97,7 @@ function Resourcer (ws) {
     }
   }
 
-  // TODO prolly should pull in something more robuts.
-  // need max attempts
+  // TODO pull in something more robuts. need max attempts constraint
   this.retry = function () {
     var self = this
     var time = self.getRetryInterval(self.retryInterval)
@@ -121,3 +119,5 @@ function Resourcer (ws) {
 }
 
 Resourcer.prototype = new EventEmitter2({wildcard: true})
+
+exports.Resourcer = Resourcer

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -19,6 +19,9 @@ const AUTH_MSG = {
 const MSG_PREFIX = 'message'
 
 module.exports = function Resourcer (options) {
+  // TODO add log level based on debug flag
+  options = parseOptions(options)
+
   var ws = null
   var resourcer = new EventEmitter2({wildcard: true})
 
@@ -29,6 +32,15 @@ module.exports = function Resourcer (options) {
       .on('message', handledMessage)
       .on('close', handledClose)
       .on('error', handledError)
+  }
+
+  function parseOptions (options) {
+    var opts = {}
+
+    // set supported options
+    opts.debug = !!opts.debug
+
+    return opts
   }
 
   // handle enables retry ws cleanup and mocking

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -61,7 +61,9 @@ module.exports = function Resourcer (options) {
 
   function handledError (err) {
     resourcer.emit('error', err)
-    retry.attempt(resourcer.connect)
+    if (err.code !== 'ECONNREFUSED' && err.address !== '127.0.0.1') {
+      retry.attempt(resourcer.connect)
+    }
   }
 
   function handledClose (code, message) {

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -1,0 +1,15 @@
+var Back = require('back')
+
+var options = {
+  minDelay: 1000,
+  maxDelay: 30000
+}
+
+var backAttempt
+
+function attempt (cb) {
+  var back = backAttempt || (backAttempt = new Back(options))
+  return back.backoff(cb)
+}
+
+module.exports.attempt = attempt

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -5,11 +5,16 @@ var options = {
   maxDelay: 30000
 }
 
-var backAttempt
+var back
 
-function attempt (cb) {
-  var back = backAttempt || (backAttempt = new Back(options))
-  return back.backoff(cb)
+module.exports = function () {
+  if (back) {
+    back.close()
+  }
+
+  back = new Back(options)
+
+  return function retry (cb) {
+    back.backoff(cb)
+  }
 }
-
-module.exports.attempt = attempt

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "hompage": "http://beepboophq.com",
+  "homepage": "http://beepboophq.com",
   "bugs": {
     "url": "https://github.com/BeepBoopHQ/beepboop-js/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "beepboop",
+  "version": "0.0.4",
+  "description": "beepboop eases hosting a botkit based bot on the beepboop hosting platform.",
+  "main": "lib/beepboop.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "beepboop",
+    "botkit",
+    "slack",
+    "bot"
+  ],
+  "author": "Chris Skudlarczyk <chris.skudlarczyk@robotsandpencils.com> (https://beepboophq.com)",
+  "license": "ISC",
+  "dependencies": {
+    "eventemitter2": "^0.4.14",
+    "https": "^1.0.0",
+    "loglevel": "^1.4.0",
+    "ws": "^1.0.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "beepboop eases hosting a botkit based bot on the beepboop hosting platform.",
   "main": "lib/beepboop.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha test"
   },
   "homepage": "http://beepboophq.com",
   "bugs": {
@@ -29,5 +29,9 @@
     "https": "^1.0.0",
     "loglevel": "^1.4.0",
     "ws": "^1.0.1"
+  },
+  "devDependencies": {
+    "mocha": "^2.4.5",
+    "sinon": "^1.17.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,14 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "hompage": "http://beepboophq.com",
+  "bugs": {
+    "url": "https://github.com/BeepBoopHQ/beepboop-js/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BeepBoopHQ/beepboop-js"
+  },
   "keywords": [
     "beepboop",
     "botkit",
@@ -15,6 +23,7 @@
   "author": "Chris Skudlarczyk <chris.skudlarczyk@robotsandpencils.com> (https://beepboophq.com)",
   "license": "ISC",
   "dependencies": {
+    "back": "^1.0.1",
     "eventemitter2": "^0.4.14",
     "https": "^1.0.0",
     "loglevel": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beepboop",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "description": "beepboop eases hosting a botkit based bot on the beepboop hosting platform.",
   "main": "lib/beepboop.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "ISC",
   "dependencies": {
     "back": "^1.0.1",
+    "deap": "^1.0.0",
     "eventemitter2": "^0.4.14",
     "https": "^1.0.0",
     "loglevel": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beepboop",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "beepboop eases hosting a botkit based bot on the beepboop hosting platform.",
   "main": "lib/beepboop.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beepboop",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "description": "beepboop eases hosting a botkit based bot on the beepboop hosting platform.",
   "main": "lib/beepboop.js",
   "scripts": {

--- a/test/resourcer_test.js
+++ b/test/resourcer_test.js
@@ -3,6 +3,7 @@ var WebSocket = require('ws')
 var assert = require('assert')
 var sinon = require('sinon')
 var Resourcer = require(__dirname + '/../lib/resourcer.js')
+var retry = require(__dirname + '/../lib/retry.js')
 
 describe('Resourcer', function () {
   var socket
@@ -14,7 +15,7 @@ describe('Resourcer', function () {
     socket.send = function () {}
     sinon.stub(WebSocket, 'connect').returns(socket)
 
-    resourcer = new Resourcer.Resourcer()
+    resourcer = new Resourcer()
     resourcer.connect(socket)
     called = false
   })
@@ -29,19 +30,17 @@ describe('Resourcer', function () {
         called = true
         assert.equal(err, 'error')
       })
-      sinon.stub(resourcer, 'retry')
 
       socket.emit('error', 'error')
       assert.equal(called, true)
     })
 
     it('handles open event', function () {
-      resourcer.on('open', function (data) {
+      resourcer.on('open', function () {
         called = true
-        assert.equal(data, 'hello')
       })
 
-      socket.emit('open', 'hello')
+      socket.emit('open')
       assert.equal(called, true)
     })
 
@@ -50,7 +49,6 @@ describe('Resourcer', function () {
         called = true
         assert.equal(reason, 'reason')
       })
-      sinon.stub(resourcer, 'retry')
 
       socket.emit('close', 'reason')
       assert.equal(called, true)

--- a/test/resourcer_test.js
+++ b/test/resourcer_test.js
@@ -1,0 +1,101 @@
+var events = require('events')
+var WebSocket = require('ws')
+var assert = require('assert')
+var sinon = require('sinon')
+var Resourcer = require(__dirname + '/../lib/resourcer.js')
+
+describe('Resourcer', function () {
+  var socket
+  var resourcer
+  var called
+
+  beforeEach(function () {
+    socket = new events.EventEmitter()
+    socket.send = function () {}
+    sinon.stub(WebSocket, 'connect').returns(socket)
+
+    resourcer = new Resourcer.Resourcer()
+    resourcer.connect(socket)
+    called = false
+  })
+
+  afterEach(function () {
+    WebSocket.connect.restore()
+  })
+
+  describe('web socket connection event handling', function () {
+    it('handles error event', function () {
+      resourcer.on('error', function (err) {
+        called = true
+        assert.equal(err, 'error')
+      })
+      sinon.stub(resourcer, 'retry')
+
+      socket.emit('error', 'error')
+      assert.equal(called, true)
+    })
+
+    it('handles open event', function () {
+      resourcer.on('open', function (data) {
+        called = true
+        assert.equal(data, 'hello')
+      })
+
+      socket.emit('open', 'hello')
+      assert.equal(called, true)
+    })
+
+    it('handles close event', function () {
+      resourcer.on('close', function (reason) {
+        called = true
+        assert.equal(reason, 'reason')
+      })
+      sinon.stub(resourcer, 'retry')
+
+      socket.emit('close', 'reason')
+      assert.equal(called, true)
+    })
+
+    describe('message events', function () {
+      it('handles add_resource event', function () {
+        resourcer.on('message.add_resource', function (msg) {
+          called = true
+          assert.deepEqual(msg, {'type': 'add_resource', 'ResourceID': '4zewnkfyldi'})
+        })
+
+        socket.emit('message', '{"type": "add_resource", "ResourceID":"4zewnkfyldi"}')
+        assert.equal(called, true)
+      })
+
+      it('handles update_resource event', function () {
+        resourcer.on('message.update_resource', function (msg) {
+          called = true
+          assert.deepEqual(msg, {'type': 'update_resource', 'ResourceID': '4zewnkfyldi-update'})
+        })
+
+        socket.emit('message', '{"type": "update_resource", "ResourceID":"4zewnkfyldi-update"}')
+        assert.equal(called, true)
+      })
+
+      it('handles remove_resource event', function () {
+        resourcer.on('message.remove_resource', function (msg) {
+          called = true
+          assert.deepEqual(msg, {'type': 'remove_resource', 'ResourceID': '4zewnkfyldi-update'})
+        })
+
+        socket.emit('message', '{"type": "remove_resource", "ResourceID":"4zewnkfyldi-update"}')
+        assert.equal(called, true)
+      })
+
+      it('handles auth_result event', function () {
+        resourcer.on('message.auth_result', function (msg) {
+          called = true
+          assert.deepEqual(msg, {'type': 'auth_result', 'ResourceID': '4zewnkfyldi-update', 'success': 'true'})
+        })
+
+        socket.emit('message', '{"type": "auth_result", "ResourceID":"4zewnkfyldi-update", "success": "true"}')
+        assert.equal(called, true)
+      })
+    })
+  })
+})

--- a/test/resourcer_test.js
+++ b/test/resourcer_test.js
@@ -57,7 +57,7 @@ describe('Resourcer', function () {
 
     describe('message events', function () {
       it('handles add_resource event', function () {
-        resourcer.on('message.add_resource', function (msg) {
+        resourcer.on('add_resource', function (msg) {
           called = true
           assert.deepEqual(msg, {'type': 'add_resource', 'ResourceID': '4zewnkfyldi'})
         })
@@ -67,7 +67,7 @@ describe('Resourcer', function () {
       })
 
       it('handles update_resource event', function () {
-        resourcer.on('message.update_resource', function (msg) {
+        resourcer.on('update_resource', function (msg) {
           called = true
           assert.deepEqual(msg, {'type': 'update_resource', 'ResourceID': '4zewnkfyldi-update'})
         })
@@ -77,7 +77,7 @@ describe('Resourcer', function () {
       })
 
       it('handles remove_resource event', function () {
-        resourcer.on('message.remove_resource', function (msg) {
+        resourcer.on('remove_resource', function (msg) {
           called = true
           assert.deepEqual(msg, {'type': 'remove_resource', 'ResourceID': '4zewnkfyldi-update'})
         })
@@ -87,7 +87,7 @@ describe('Resourcer', function () {
       })
 
       it('handles auth_result event', function () {
-        resourcer.on('message.auth_result', function (msg) {
+        resourcer.on('auth_result', function (msg) {
           called = true
           assert.deepEqual(msg, {'type': 'auth_result', 'ResourceID': '4zewnkfyldi-update', 'success': 'true'})
         })

--- a/test/resourcer_test.js
+++ b/test/resourcer_test.js
@@ -3,7 +3,6 @@ var WebSocket = require('ws')
 var assert = require('assert')
 var sinon = require('sinon')
 var Resourcer = require(__dirname + '/../lib/resourcer.js')
-var retry = require(__dirname + '/../lib/retry.js')
 
 describe('Resourcer', function () {
   var socket

--- a/test/resourcer_test.js
+++ b/test/resourcer_test.js
@@ -45,12 +45,13 @@ describe('Resourcer', function () {
     })
 
     it('handles close event', function () {
-      resourcer.on('close', function (reason) {
+      resourcer.on('close', function (code, message) {
         called = true
-        assert.equal(reason, 'reason')
+        assert.equal(code, 1000)
+        assert.equal(message, 'closed')
       })
 
-      socket.emit('close', 'reason')
+      socket.emit('close', 1000, 'closed')
       assert.equal(called, true)
     })
 


### PR DESCRIPTION
#### What's this PR do?

Adds ability to connect to a Beep Boop Resourcer server and listen for events. Events should serve to notify a bot maker when users (team owners typically) have requested to add, update, remove the bot from their team.

This is the lowest level module for running on beep boop. A beepboop-botkit module will wrap this module and handle adding, updating, and removing teams the botkit way.

The most useful events are `message.add_resource`, `message.update_resource`, `message.remove_resource`. -- the namespaces are up for debate and worth discussing via this PR.
#### Where should the reviewer start?

It's pretty much all in the lib/resourcer.js. Worth looking at lib/retry.js as well.

Also, would be good to sanity check the README to make sure it's intuitive.
#### How should this be manually tested?

Against real beepboop resource server would be ideal.

set:
      export BEEPBOOP_TOKEN={the resourcer token},
      export BEEPBOOP_ID={the pod id}
      export BEEPBOOP_RESOURCER={the resourcer web socket url ex: 'ws://localhost:9000/ws'}

`node ./examples/simple.js`

trigger add, update, remove events on resourcer. you should see the console logs coming from the bot process.
#### Were the tests updated? yes but need coverage around retry.
