### PR TITLE
handling error in backoff wrapper & bumping up retries to Infinity

### DIFF
--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -14,7 +14,7 @@ module.exports = function Resourcer (config) {
   var resourcer = new EventEmitter2({wildcard: true})
   resourcer.log = log
 
-  resourcer.connect = function (inWs) {
+  resourcer.connect = function () {
     cleanup()
     ws = resourcer.newWebSocket()
     ws

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -15,7 +15,8 @@ module.exports = function Resourcer (config) {
   resourcer.log = log
 
   resourcer.connect = function (inWs) {
-    ws = initWs(inWs)
+    cleanup()
+    ws = resourcer.newWebSocket()
     ws
       .on('open', handledOpen)
       .on('message', handledMessage)
@@ -37,18 +38,14 @@ module.exports = function Resourcer (config) {
     return cfg
   }
 
-  // cleanup and recreate ws connection for retry and mock case
-  function initWs (inWs) {
+  function cleanup () {
     if (ws) {
       ws.removeAllListeners()
-      // this is a noop if already closed
       ws.close()
     }
-
-    return inWs || newWs()
   }
 
-  function newWs () {
+  resourcer.newWebSocket = function () {
     try {
       var ws = new WebSocket(config.serverURL)
     } catch (e) {

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -2,7 +2,8 @@ var Back = require('back')
 
 var options = {
   minDelay: 1000,
-  maxDelay: 30000
+  maxDelay: 30000,
+  retries: Infinity
 }
 
 var back
@@ -15,6 +16,14 @@ module.exports = function () {
   back = new Back(options)
 
   return function retry (cb) {
-    back.backoff(cb)
+    back.backoff(function (err) {
+      // If backoff fails for some reason, reset it
+      if (err) {
+        back.close()
+        back = new Back(options)
+      }
+
+      cb()
+    })
   }
 }

--- a/test/resourcer_test.js
+++ b/test/resourcer_test.js
@@ -1,5 +1,4 @@
 var events = require('events')
-var WebSocket = require('ws')
 var assert = require('assert')
 var sinon = require('sinon')
 var Resourcer = require('../lib/resourcer.js')
@@ -10,17 +9,18 @@ describe('Resourcer', function () {
   var called
 
   beforeEach(function () {
+    resourcer = new Resourcer()
+
     socket = new events.EventEmitter()
     socket.send = function () {}
-    sinon.stub(WebSocket, 'connect').returns(socket)
+    sinon.stub(resourcer, 'newWebSocket').returns(socket)
 
-    resourcer = new Resourcer()
     resourcer.connect(socket)
     called = false
   })
 
   afterEach(function () {
-    WebSocket.connect.restore()
+    resourcer.newWebSocket.restore()
   })
 
   describe('web socket connection event handling', function () {


### PR DESCRIPTION
`back` - the library we're using for our retry backoff logic, defaults to 10 retries, and passes along an error to the callback after that is reached.  This error was getting consumed as what is an optional `WebSocket` paramter to the `connect()` function, which is only used for mocking in tests.

I've removed the optional `inWs` parameter from the `connect()` function, and am mocking a `newWebSocket` function that I've moved some logic into instead.

I've also wrapper the retry callback to handle an error should one be returned from `back` now - and am resetting the backoff object in that case.

Lastly, I bumped the retries from the default of `10` to `Infinity` - as we don't want it to ever stop retrying.

Fixes #2 
