### PR TITLE
Add ping/pong message support to detect stale connections

### DIFF
--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -102,7 +102,7 @@ module.exports = function Resourcer (config) {
 
   function handledClose (code, message) {
     resourcer.emit('close', code, message)
-    log.debug('Connection to Beep Boop server closed.', code, message)
+    log.debug('Connection to Beep Boop server closed.', code || "", message || "")
 
     retry(resourcer.connect)
   }
@@ -127,12 +127,10 @@ module.exports = function Resourcer (config) {
       return
     }
 
-    log.debug('Sending PING to Beep Boop server')
-    ws.ping()
+    ws.ping(null, null, true);
   }
 
   function handlePong () {
-    log.debug('Received PONG from Beep Boop server')
     lastReceivedPong = Date.now()
   }
 

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -11,6 +11,8 @@ module.exports = function Resourcer (config) {
 
   var ws = null
   var retry = Retry()
+  var pingInterval = null
+  var lastReceivedPong = 0
   var resourcer = new EventEmitter2({wildcard: true})
   resourcer.log = log
 
@@ -22,6 +24,7 @@ module.exports = function Resourcer (config) {
       .on('message', handledMessage)
       .on('close', handledClose)
       .on('error', handledError)
+      .on('pong', handlePong)
 
     return resourcer
   }
@@ -32,7 +35,9 @@ module.exports = function Resourcer (config) {
       token: process.env.BEEPBOOP_TOKEN,
       id: process.env.BEEPBOOP_ID,
       serverURL: process.env.BEEPBOOP_RESOURCER,
-      logger: null
+      logger: null,
+      pingFrequency: 5000,
+      pongTimeout: 12000
     }, config || {})
 
     return cfg
@@ -43,6 +48,10 @@ module.exports = function Resourcer (config) {
       ws.removeAllListeners()
       ws.close()
     }
+    if (pingInterval) {
+      clearInterval(pingInterval)
+    }
+    lastReceivedPong = 0
   }
 
   resourcer.newWebSocket = function () {
@@ -75,6 +84,7 @@ module.exports = function Resourcer (config) {
     log.debug('Web Socket connection opened to Beep Boop Server:', config.serverURL)
     // Reset retry backoff
     retry = Retry()
+    pingInterval = setInterval(pingPonger, config.pingFrequency)
   }
 
   function handledError (err) {
@@ -108,6 +118,22 @@ module.exports = function Resourcer (config) {
       log.error('Error attempting JSON.parse of message from Beep Boop server. ', err.toString())
       return
     }
+  }
+
+  function pingPonger () {
+    if (lastReceivedPong && (lastReceivedPong + config.pongTimeout < Date.now())) {
+      log.debug('Beep Boop server connection is stale, closing connection')
+      handledClose()
+      return
+    }
+
+    log.debug('Sending PING to Beep Boop server')
+    ws.ping()
+  }
+
+  function handlePong () {
+    log.debug('Received PONG from Beep Boop server')
+    lastReceivedPong = Date.now()
   }
 
   return resourcer

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -102,7 +102,7 @@ module.exports = function Resourcer (config) {
 
   function handledClose (code, message) {
     resourcer.emit('close', code, message)
-    log.debug('Connection to Beep Boop server closed.', code || "", message || "")
+    log.debug('Connection to Beep Boop server closed.', code || '', message || '')
 
     retry(resourcer.connect)
   }
@@ -127,7 +127,7 @@ module.exports = function Resourcer (config) {
       return
     }
 
-    ws.ping(null, null, true);
+    ws.ping(null, null, true)
   }
 
   function handlePong () {


### PR DESCRIPTION
#### What's this PR do?

Adds websocket protocol ping and pong support to detect stale/broken connections
#### How should this be manually tested?

Connect and then disconnect, perhaps by disabling the network interface or taking down the resourcer. Then reverse that change and make sure things reconnect.
