### PR TITLE
Message error catch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "4"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Module has exported function `start`
 * Emitted when the connection is established.
 
 ```javascript
-beepboop.on('open', function () { 
+beepboop.on('open', function () {
   console.log('connection to Beep Boop server opened')
 })
 ```
@@ -63,7 +63,7 @@ beepboop.on('open', function () {
 * Errors with the connection and underlying WebSocket are emitted here.
 
 ```javascript
-beepboop.on('error', function (error) { 
+beepboop.on('error', function (error) {
   console.log('Error from Beep Boop connection: ', err)
 })
 ```
@@ -73,7 +73,7 @@ beepboop.on('error', function (error) {
 * Is emitted when the WebSocket connection is closed.
 
 ```javascript
-beepboop.on('close', function (code, message) { 
+beepboop.on('close', function (code, message) {
   console.log('Connection to Beep Boop was closed')
 }
 ```
@@ -83,7 +83,7 @@ beepboop.on('close', function (code, message) {
 Is emitted when an `add_resource` message is received, indicating a user has requested an instance of the bot to be added to their team.
 
 ```javascript
-beepboop.on('add_resource', function (message) { 
+beepboop.on('add_resource', function (message) {
   console.log('Team added: ', message)
   // Create a connection to the Slack RTM on behalf of the team
 })
@@ -102,7 +102,13 @@ An `add_resource` `message` looks as follows:
   "resource": {
     // Token you should use to connect to the Slack RTM API
     "SlackBotAccessToken": "xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx",
+    "SlackBotUserID": "XXXXXXXXX",
+    "SlackBotUserName": "name-of-bot-user",
+    // Regular access token - will contain additional scopes requested
+    "SlackAccessToken": "XXXXXXXXX",
+    "SlackTeamName": "Name of Team",
     "SlackTeamID": "XXXXXXXXX",
+    "SlackUserID": "XXXXXXXXX",
     "CUSTOM_CONFIG": "Value for CUSTOM_CONFIG"
   }
 }
@@ -116,7 +122,7 @@ For keeping track of multiple team's RTM socket connections, you would want to c
 * Is emitted when an `update_resource` message is received, indicating a request to update the instance of the bot has been sent. The bot maker updating the bot, or a bot owner updating configuration are two cases that can trigger an update.
 
 ```javascript
-beepboop.on('update_resource', function (message) { 
+beepboop.on('update_resource', function (message) {
   console.log('Team Updated: ', message)
   // may need to update local config for team or re-establish the Slack RTM connection
 })
@@ -131,8 +137,15 @@ An `update_resource` message looks as follows, very similar to the `add_resource
   "msgID": "2ca94d34-ef04-4167-8363-c778d129b8f1",
   "resourceID": "75f9c7334807421bb914c1cff8d4486c",
   "resource": {
+    // Token you should use to connect to the Slack RTM API
     "SlackBotAccessToken": "xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx",
+    "SlackBotUserID": "XXXXXXXXX",
+    "SlackBotUserName": "name-of-bot-user",
+    // Regular access token - will contain additional scopes requested
+    "SlackAccessToken": "XXXXXXXXX",
+    "SlackTeamName": "Name of Team",
     "SlackTeamID": "XXXXXXXXX",
+    "SlackUserID": "XXXXXXXXX",
     "CUSTOM_CONFIG": "Updated Value for Config"
   }
 }
@@ -143,7 +156,7 @@ An `update_resource` message looks as follows, very similar to the `add_resource
 * Is emitted when an `remove_resource` message is received, indicating a bot owner has removed a bot from their team.  You should disconnect from the Slack RTM API on behalf of the requested team.
 
 ```javascript
-beepboop.on('remove_resource', function (message) { 
+beepboop.on('remove_resource', function (message) {
   console.log('Team Removed: ', message)
   // You'll want to disconnect from the Slack RTM connection you made, and perform any cleanup needed
 })
@@ -159,4 +172,3 @@ A `remove_resource` message looks as follows:
   "resourceID": "75f9c7334807421bb914c1cff8d4486c"
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/BeepBoopHQ/beepboop-js.svg)](https://travis-ci.org/BeepBoopHQ/beepboop-js)
+
 ## The beepboop bot multi-team management node module
 
 `beepboop` allows bot developers to run on the [Beep Boop HQ](https://beepboophq.com) bot hosting platform and support multiple teams from a single bot process. Simply require `beepboop` in your bot project and listen for events indicating a user has requested your bot to be added, updated, or removed from their team.

--- a/lib/resourcer.js
+++ b/lib/resourcer.js
@@ -111,13 +111,14 @@ module.exports = function Resourcer (config) {
     var msg = null
     try {
       msg = JSON.parse(payload)
-      resourcer.emit(msg.type, msg)
-      log.debug('Message received from Beep Boop server: ', JSON.stringify(msg))
     } catch (err) {
       resourcer.emit('error', err)
       log.error('Error attempting JSON.parse of message from Beep Boop server. ', err.toString())
       return
     }
+
+    resourcer.emit(msg.type, msg)
+    log.debug('Message received from Beep Boop server: ', JSON.stringify(msg))
   }
 
   function pingPonger () {

--- a/test/resourcer_test.js
+++ b/test/resourcer_test.js
@@ -94,6 +94,30 @@ describe('Resourcer', function () {
         socket.emit('message', '{"type": "auth_result", "ResourceID":"4zewnkfyldi-update", "success": "true"}')
         assert.equal(called, true)
       })
+
+      it('handles a bad message', function () {
+        resourcer.on('error', function () {
+          called = true
+        })
+
+        socket.emit('message', '{"type": ""auth_result", "ResourceID":"4zewnkfyldi-update", "success": "true"}')
+        assert.equal(called, true)
+      })
+
+      it('does not emit an error if listener throws', function () {
+        var spy = sinon.spy(resourcer, 'on')
+        resourcer.on('auth_result', function () {
+          throw new Error('kaboom')
+        })
+
+        try {
+          socket.emit('message', '{"type": "auth_result", "ResourceID":"4zewnkfyldi-update", "success": "true"}')
+        } catch (e) {
+          assert.equal(e.message, 'kaboom')
+        }
+
+        assert.equal(spy.calledWith('error'), false)
+      })
     })
   })
 })

--- a/test/resourcer_test.js
+++ b/test/resourcer_test.js
@@ -6,7 +6,6 @@ var Resourcer = require('../lib/resourcer.js')
 describe('Resourcer', function () {
   var socket
   var resourcer
-  var called
 
   beforeEach(function () {
     resourcer = new Resourcer()
@@ -16,7 +15,6 @@ describe('Resourcer', function () {
     sinon.stub(resourcer, 'newWebSocket').returns(socket)
 
     resourcer.connect(socket)
-    called = false
   })
 
   afterEach(function () {
@@ -25,6 +23,7 @@ describe('Resourcer', function () {
 
   describe('web socket connection event handling', function () {
     it('handles error event', function () {
+      var called = false
       resourcer.on('error', function (err) {
         called = true
         assert.equal(err, 'error')
@@ -35,67 +34,54 @@ describe('Resourcer', function () {
     })
 
     it('handles open event', function () {
-      resourcer.on('open', function () {
-        called = true
-      })
+      var spy = sinon.spy(resourcer, 'emit')
 
       socket.emit('open')
-      assert.equal(called, true)
+      assert(spy.calledWith('open'))
     })
 
     it('handles close event', function () {
-      resourcer.on('close', function (code, message) {
-        called = true
-        assert.equal(code, 1000)
-        assert.equal(message, 'closed')
-      })
+      var spy = sinon.spy(resourcer, 'emit')
 
       socket.emit('close', 1000, 'closed')
-      assert.equal(called, true)
+      assert(spy.calledWith('close', 1000, 'closed'))
     })
 
     describe('message events', function () {
       it('handles add_resource event', function () {
-        resourcer.on('add_resource', function (msg) {
-          called = true
-          assert.deepEqual(msg, {'type': 'add_resource', 'ResourceID': '4zewnkfyldi'})
-        })
+        var spy = sinon.spy(resourcer, 'emit')
+        var message = {'type': 'add_resource', 'ResourceID': '4zewnkfyldi'}
 
-        socket.emit('message', '{"type": "add_resource", "ResourceID":"4zewnkfyldi"}')
-        assert.equal(called, true)
+        socket.emit('message', JSON.stringify(message))
+        assert.equal(spy.calledWith('add_resource', message), true)
       })
 
       it('handles update_resource event', function () {
-        resourcer.on('update_resource', function (msg) {
-          called = true
-          assert.deepEqual(msg, {'type': 'update_resource', 'ResourceID': '4zewnkfyldi-update'})
-        })
+        var spy = sinon.spy(resourcer, 'emit')
+        var message = {'type': 'update_resource', 'ResourceID': '4zewnkfyldi-update'}
 
-        socket.emit('message', '{"type": "update_resource", "ResourceID":"4zewnkfyldi-update"}')
-        assert.equal(called, true)
+        socket.emit('message', JSON.stringify(message))
+        assert.equal(spy.calledWith('update_resource', message), true)
       })
 
       it('handles remove_resource event', function () {
-        resourcer.on('remove_resource', function (msg) {
-          called = true
-          assert.deepEqual(msg, {'type': 'remove_resource', 'ResourceID': '4zewnkfyldi-update'})
-        })
+        var spy = sinon.spy(resourcer, 'emit')
+        var message = {'type': 'remove_resource', 'ResourceID': '4zewnkfyldi-update'}
 
-        socket.emit('message', '{"type": "remove_resource", "ResourceID":"4zewnkfyldi-update"}')
-        assert.equal(called, true)
+        socket.emit('message', JSON.stringify(message))
+        assert.equal(spy.calledWith('remove_resource', message), true)
       })
 
       it('handles auth_result event', function () {
-        resourcer.on('auth_result', function (msg) {
-          called = true
-          assert.deepEqual(msg, {'type': 'auth_result', 'ResourceID': '4zewnkfyldi-update', 'success': 'true'})
-        })
+        var spy = sinon.spy(resourcer, 'emit')
+        var message = {'type': 'auth_result', 'ResourceID': '4zewnkfyldi-update', 'success': 'true'}
 
-        socket.emit('message', '{"type": "auth_result", "ResourceID":"4zewnkfyldi-update", "success": "true"}')
-        assert.equal(called, true)
+        socket.emit('message', JSON.stringify(message))
+        assert.equal(spy.calledWith('auth_result', message), true)
       })
 
       it('handles a bad message', function () {
+        var called = false
         resourcer.on('error', function () {
           called = true
         })
@@ -105,7 +91,7 @@ describe('Resourcer', function () {
       })
 
       it('does not emit an error if listener throws', function () {
-        var spy = sinon.spy(resourcer, 'on')
+        var spy = sinon.spy(resourcer, 'emit')
         resourcer.on('auth_result', function () {
           throw new Error('kaboom')
         })


### PR DESCRIPTION
- Move code where we emit messages, such as `add_resource`, so it's outside of a try/catch.  Currently if userland code is listening for these events, and throws an error in their listener, we're consuming it, and surfacing it in what looks like a `JSON.parse()` error due to the message we log.  This pulls that out of the try/catch that is there for the `JSON.parse()`
- Also updated a few tests for consistency
- Updated readme with new message properties
